### PR TITLE
Ensure xml2mask.py can be executed

### DIFF
--- a/code/xml2mask.py
+++ b/code/xml2mask.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python3
+
+"""
+This script converts DICOM files to NIfTI format using pydicom and nibabel libraries.
+It takes two command-line arguments: the directory containing the DICOM files and the directory to save the converted NIfTI files.
+"""
+
 import os
 import pydicom
 import nibabel as nib
@@ -5,6 +12,8 @@ import numpy as np
 import argparse
 
 def dicom_to_nifti(dicom_dir, output_dir):
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
     for patient_id in os.listdir(dicom_dir):
         patient_dir = os.path.join(dicom_dir, patient_id)
         if os.path.isdir(patient_dir):


### PR DESCRIPTION
Add shebang line, docstring, and output directory check to `code/xml2mask.py`.

* Add a shebang line at the top of the file to specify the Python interpreter.
* Add a docstring at the beginning of the file to describe the purpose of the script.
* Add a check to ensure the output directory exists, and create it if it doesn't.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jamesgoldfarb/cs230-Coronary-Calcium-Scoring-/pull/2?shareId=efd4eae3-34b8-4bd5-9f50-fd3ad637c13c).